### PR TITLE
feat: Add schedule side, medical history, reservation side entities and repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+.idea
+.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	runtimeOnly 'mysql:mysql-connector-java'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build/generated/querydsl/com/petclinic/backend/domain/entity/QDoctorSchedule.java
+++ b/build/generated/querydsl/com/petclinic/backend/domain/entity/QDoctorSchedule.java
@@ -1,0 +1,55 @@
+package com.petclinic.backend.domain.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QDoctorSchedule is a Querydsl query type for DoctorSchedule
+ */
+@Generated("com.querydsl.codegen.EntitySerializer")
+public class QDoctorSchedule extends EntityPathBase<DoctorSchedule> {
+
+    private static final long serialVersionUID = -1953453915L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QDoctorSchedule doctorSchedule = new QDoctorSchedule("doctorSchedule");
+
+    public final QDoctorScheduleId id;
+
+    public final NumberPath<Pet> pet = createNumber("pet", Pet.class);
+
+    public final StringPath remark = createString("remark");
+
+    public final NumberPath<Reservation> reservation = createNumber("reservation", Reservation.class);
+
+    public QDoctorSchedule(String variable) {
+        this(DoctorSchedule.class, forVariable(variable), INITS);
+    }
+
+    public QDoctorSchedule(Path<? extends DoctorSchedule> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QDoctorSchedule(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QDoctorSchedule(PathMetadata metadata, PathInits inits) {
+        this(DoctorSchedule.class, metadata, inits);
+    }
+
+    public QDoctorSchedule(Class<? extends DoctorSchedule> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.id = inits.isInitialized("id") ? new QDoctorScheduleId(forProperty("id")) : null;
+    }
+
+}
+

--- a/build/generated/querydsl/com/petclinic/backend/domain/entity/QDoctorScheduleId.java
+++ b/build/generated/querydsl/com/petclinic/backend/domain/entity/QDoctorScheduleId.java
@@ -1,0 +1,39 @@
+package com.petclinic.backend.domain.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QDoctorScheduleId is a Querydsl query type for DoctorScheduleId
+ */
+@Generated("com.querydsl.codegen.EmbeddableSerializer")
+public class QDoctorScheduleId extends BeanPath<DoctorScheduleId> {
+
+    private static final long serialVersionUID = -368501600L;
+
+    public static final QDoctorScheduleId doctorScheduleId = new QDoctorScheduleId("doctorScheduleId");
+
+    public final NumberPath<Doctor> doctor = createNumber("doctor", Doctor.class);
+
+    public final DateTimePath<java.time.LocalDateTime> scheduleTS = createDateTime("scheduleTS", java.time.LocalDateTime.class);
+
+    public QDoctorScheduleId(String variable) {
+        super(DoctorScheduleId.class, forVariable(variable));
+    }
+
+    public QDoctorScheduleId(Path<? extends DoctorScheduleId> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QDoctorScheduleId(PathMetadata metadata) {
+        super(DoctorScheduleId.class, metadata);
+    }
+
+}
+

--- a/build/generated/querydsl/com/petclinic/backend/domain/entity/QInfra.java
+++ b/build/generated/querydsl/com/petclinic/backend/domain/entity/QInfra.java
@@ -1,0 +1,45 @@
+package com.petclinic.backend.domain.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QInfra is a Querydsl query type for Infra
+ */
+@Generated("com.querydsl.codegen.EntitySerializer")
+public class QInfra extends EntityPathBase<Infra> {
+
+    private static final long serialVersionUID = 691711265L;
+
+    public static final QInfra infra = new QInfra("infra");
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Hospital> hospital = createNumber("hospital", Hospital.class);
+
+    public final StringPath id = createString("id");
+
+    public final NumberPath<Integer> maxWeight = createNumber("maxWeight", Integer.class);
+
+    public final StringPath name = createString("name");
+
+    public QInfra(String variable) {
+        super(Infra.class, forVariable(variable));
+    }
+
+    public QInfra(Path<? extends Infra> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QInfra(PathMetadata metadata) {
+        super(Infra.class, metadata);
+    }
+
+}
+

--- a/build/generated/querydsl/com/petclinic/backend/domain/entity/QInfraSchedule.java
+++ b/build/generated/querydsl/com/petclinic/backend/domain/entity/QInfraSchedule.java
@@ -1,0 +1,55 @@
+package com.petclinic.backend.domain.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QInfraSchedule is a Querydsl query type for InfraSchedule
+ */
+@Generated("com.querydsl.codegen.EntitySerializer")
+public class QInfraSchedule extends EntityPathBase<InfraSchedule> {
+
+    private static final long serialVersionUID = -2058292520L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QInfraSchedule infraSchedule = new QInfraSchedule("infraSchedule");
+
+    public final QInfraScheduleId id;
+
+    public final NumberPath<Pet> pet = createNumber("pet", Pet.class);
+
+    public final StringPath remark = createString("remark");
+
+    public final NumberPath<Reservation> reservation = createNumber("reservation", Reservation.class);
+
+    public QInfraSchedule(String variable) {
+        this(InfraSchedule.class, forVariable(variable), INITS);
+    }
+
+    public QInfraSchedule(Path<? extends InfraSchedule> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QInfraSchedule(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QInfraSchedule(PathMetadata metadata, PathInits inits) {
+        this(InfraSchedule.class, metadata, inits);
+    }
+
+    public QInfraSchedule(Class<? extends InfraSchedule> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.id = inits.isInitialized("id") ? new QInfraScheduleId(forProperty("id"), inits.get("id")) : null;
+    }
+
+}
+

--- a/build/generated/querydsl/com/petclinic/backend/domain/entity/QInfraScheduleId.java
+++ b/build/generated/querydsl/com/petclinic/backend/domain/entity/QInfraScheduleId.java
@@ -1,0 +1,51 @@
+package com.petclinic.backend.domain.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QInfraScheduleId is a Querydsl query type for InfraScheduleId
+ */
+@Generated("com.querydsl.codegen.EmbeddableSerializer")
+public class QInfraScheduleId extends BeanPath<InfraScheduleId> {
+
+    private static final long serialVersionUID = 1960814099L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QInfraScheduleId infraScheduleId = new QInfraScheduleId("infraScheduleId");
+
+    public final QInfra infra;
+
+    public final DateTimePath<java.time.LocalDateTime> scheduleTS = createDateTime("scheduleTS", java.time.LocalDateTime.class);
+
+    public QInfraScheduleId(String variable) {
+        this(InfraScheduleId.class, forVariable(variable), INITS);
+    }
+
+    public QInfraScheduleId(Path<? extends InfraScheduleId> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QInfraScheduleId(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QInfraScheduleId(PathMetadata metadata, PathInits inits) {
+        this(InfraScheduleId.class, metadata, inits);
+    }
+
+    public QInfraScheduleId(Class<? extends InfraScheduleId> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.infra = inits.isInitialized("infra") ? new QInfra(forProperty("infra")) : null;
+    }
+
+}
+

--- a/build/generated/querydsl/com/petclinic/backend/domain/entity/QMedicalHistory.java
+++ b/build/generated/querydsl/com/petclinic/backend/domain/entity/QMedicalHistory.java
@@ -1,0 +1,69 @@
+package com.petclinic.backend.domain.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMedicalHistory is a Querydsl query type for MedicalHistory
+ */
+@Generated("com.querydsl.codegen.EntitySerializer")
+public class QMedicalHistory extends EntityPathBase<MedicalHistory> {
+
+    private static final long serialVersionUID = 341195922L;
+
+    public static final QMedicalHistory medicalHistory = new QMedicalHistory("medicalHistory");
+
+    public final StringPath amount = createString("amount");
+
+    public final StringPath by = createString("by");
+
+    public final NumberPath<Code> code = createNumber("code", Code.class);
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Doctor> doctor = createNumber("doctor", Doctor.class);
+
+    public final DateTimePath<java.time.LocalDateTime> historyTS = createDateTime("historyTS", java.time.LocalDateTime.class);
+
+    public final NumberPath<Hospital> hospital = createNumber("hospital", Hospital.class);
+
+    public final StringPath id = createString("id");
+
+    public final StringPath journal = createString("journal");
+
+    public final NumberPath<Pet> pet = createNumber("pet", Pet.class);
+
+    public final StringPath photo = createString("photo");
+
+    public final StringPath qty = createString("qty");
+
+    public final NumberPath<Type> type = createNumber("type", Type.class);
+
+    public final NumberPath<UserGroup> usergroup = createNumber("usergroup", UserGroup.class);
+
+    public final StringPath variance = createString("variance");
+
+    public final StringPath xls = createString("xls");
+
+    public final StringPath zip = createString("zip");
+
+    public QMedicalHistory(String variable) {
+        super(MedicalHistory.class, forVariable(variable));
+    }
+
+    public QMedicalHistory(Path<? extends MedicalHistory> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMedicalHistory(PathMetadata metadata) {
+        super(MedicalHistory.class, metadata);
+    }
+
+}
+

--- a/build/resources/main/application.properties
+++ b/build/resources/main/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/example?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=1234

--- a/build/tmp/compileJava/source-classes-mapping.txt
+++ b/build/tmp/compileJava/source-classes-mapping.txt
@@ -1,0 +1,2 @@
+com/petclinic/backend/BackendApplication.java
+ com.petclinic.backend.BackendApplication

--- a/src/main/java/com/petclinic/backend/domain/entity/DoctorSchedule.java
+++ b/src/main/java/com/petclinic/backend/domain/entity/DoctorSchedule.java
@@ -1,0 +1,25 @@
+package com.petclinic.backend.domain.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "doctor_schedule_tb")
+@Getter
+public class DoctorSchedule {
+    @EmbeddedId
+    private DoctorScheduleId id;
+
+    @JoinColumn(name = "pet_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Pet pet;
+
+    @JoinColumn(name = "reservation_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Reservation reservation;
+
+    @Column(name = "remark")
+    private String remark;
+
+}

--- a/src/main/java/com/petclinic/backend/domain/entity/DoctorScheduleId.java
+++ b/src/main/java/com/petclinic/backend/domain/entity/DoctorScheduleId.java
@@ -1,0 +1,22 @@
+package com.petclinic.backend.domain.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Embeddable
+@Getter
+public class DoctorScheduleId {
+    @Column(name = "schedule_ts")
+    private LocalDateTime scheduleTS;
+
+    @JoinColumn(name = "doctor_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Doctor doctor;
+
+    public DoctorScheduleId(LocalDateTime scheduleTS, Doctor doctor){
+        this.scheduleTS = scheduleTS;
+        this.doctor = doctor;
+    }
+}

--- a/src/main/java/com/petclinic/backend/domain/entity/Infra.java
+++ b/src/main/java/com/petclinic/backend/domain/entity/Infra.java
@@ -1,0 +1,29 @@
+package com.petclinic.backend.domain.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "infra_tb")
+@Getter
+public class Infra {
+    @Id
+    @GeneratedValue
+    @Column(name = "id")
+    private String id;
+
+    @JoinColumn(name = "hospital_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Hospital hospital;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "max_weight")
+    private int maxWeight;
+
+}

--- a/src/main/java/com/petclinic/backend/domain/entity/InfraSchedule.java
+++ b/src/main/java/com/petclinic/backend/domain/entity/InfraSchedule.java
@@ -1,0 +1,25 @@
+package com.petclinic.backend.domain.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "infra_schedule_tb")
+@Getter
+public class InfraSchedule {
+    @EmbeddedId
+    private InfraScheduleId id;
+
+    @JoinColumn(name = "pet_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Pet pet;
+
+    @JoinColumn(name = "reservation_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Reservation reservation;
+
+    @Column(name = "remark")
+    private String remark;
+
+}

--- a/src/main/java/com/petclinic/backend/domain/entity/InfraScheduleId.java
+++ b/src/main/java/com/petclinic/backend/domain/entity/InfraScheduleId.java
@@ -1,0 +1,22 @@
+package com.petclinic.backend.domain.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Embeddable
+@Getter
+public class InfraScheduleId {
+    @Column(name = "schedule_ts")
+    private LocalDateTime scheduleTS;
+
+    @JoinColumn(name = "infra_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Infra infra;
+
+    public InfraScheduleId(LocalDateTime scheduleTS, Infra infra){
+        this.scheduleTS = scheduleTS;
+        this.infra = infra;
+    }
+}

--- a/src/main/java/com/petclinic/backend/domain/entity/MedicalHistory.java
+++ b/src/main/java/com/petclinic/backend/domain/entity/MedicalHistory.java
@@ -1,0 +1,71 @@
+package com.petclinic.backend.domain.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "medical_history_tb")
+@Getter
+public class MedicalHistory {
+    @Id
+    @GeneratedValue
+    @Column(name = "id")
+    private String id;
+
+    @JoinColumn(name = "usergroup_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private UserGroup usergroup;
+
+    @JoinColumn(name = "doctor_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Doctor doctor;
+
+    @JoinColumn(name = "pet_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Pet pet;
+
+    @JoinColumn(name = "hospital_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Hospital hospital;
+
+    @Column(name = "history_ts")
+    private LocalDateTime historyTS;
+
+    @JoinColumn(name = "type_cd")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Type type;
+
+    @JoinColumn(name = "code_cd")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Code code;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "qty")
+    private String qty;
+
+    @Column(name = "amount")
+    private String amount;
+
+    @Column(name = "by")
+    private String by;
+
+    @Column(name = "photo")
+    private String photo;
+
+    @Column(name = "xls")
+    private String xls;
+
+    @Column(name = "variance")
+    private String variance;
+
+    @Column(name = "journal")
+    private String journal;
+
+    @Column(name = "zip")
+    private String zip;
+
+}

--- a/src/main/java/com/petclinic/backend/domain/entity/Payment.java
+++ b/src/main/java/com/petclinic/backend/domain/entity/Payment.java
@@ -1,0 +1,37 @@
+package com.petclinic.backend.domain.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payment_tb")
+@Getter
+public class Payment {
+    @Id
+    @GeneratedValue
+    @Column(name = "id")
+    private String id;
+
+    @JoinColumn(name = "reception_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Reception reception;
+
+    @Column(name = "collection_ts")
+    private LocalDateTime collectionTS;
+
+    @Column(name = "charging_ts")
+    private LocalDateTime chargingTS;
+
+    @Column(name = "charging_name")
+    private String chargingName;
+
+    @Column(name = "charging_fee")
+    private String chargingFee;
+
+    @JoinColumn(name = "payment_type_cd")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Code paymentType;
+
+}

--- a/src/main/java/com/petclinic/backend/domain/entity/Reception.java
+++ b/src/main/java/com/petclinic/backend/domain/entity/Reception.java
@@ -1,0 +1,49 @@
+package com.petclinic.backend.domain.entity;
+
+import lombok.Getter;
+import org.aspectj.apache.bcel.classfile.Code;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reception_tb")
+@Getter
+public class Reception {
+    @Id
+    @GeneratedValue
+    @Column(name = "id")
+    private String id;
+
+    @JoinColumn(name = "reservation_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Reservation reservation;
+
+    @Column(name = "reception_ts")
+    private LocalDateTime receptionTS;
+
+    @JoinColumn(name = "category_cd")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Code category;
+
+    @JoinColumn(name = "usergroup_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Usergroup usergroup;
+
+    @JoinColumn(name = "pet_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Pet pet;
+
+    @JoinColumn(name = "hospital_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Hospital hospital;
+
+    @JoinColumn(name = "doctor_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Doctor doctor;
+
+    @JoinColumn(name = "infra_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Infra infra;
+
+}

--- a/src/main/java/com/petclinic/backend/domain/entity/Reservation.java
+++ b/src/main/java/com/petclinic/backend/domain/entity/Reservation.java
@@ -1,0 +1,47 @@
+package com.petclinic.backend.domain.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reservation_tb")
+@Getter
+public class Reservation {
+    @Id
+    @GeneratedValue
+    @Column(name = "id")
+    private String id;
+
+    @Column(name = "reservation_ts")
+    private LocalDateTime reservationTS;
+
+    @JoinColumn(name = "state_cd")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Code state;
+
+    @JoinColumn(name = "category_cd")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Code category;
+
+    @JoinColumn(name = "usergroup_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Usergroup usergroup;
+
+    @JoinColumn(name = "pet_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Pet pet;
+
+    @JoinColumn(name = "hospital_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Hospital hospital;
+
+    @JoinColumn(name = "doctor_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Doctor doctor;
+
+    @Column(name = "remark")
+    private String remark;
+
+}

--- a/src/main/java/com/petclinic/backend/domain/repository/DoctorScheduleRepository.java
+++ b/src/main/java/com/petclinic/backend/domain/repository/DoctorScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.petclinic.backend.domain.repository;
+
+import com.petclinic.backend.domain.entity.DoctorSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DoctorScheduleRepository extends JpaRepository<DoctorSchedule, String> {
+}

--- a/src/main/java/com/petclinic/backend/domain/repository/InfraRepository.java
+++ b/src/main/java/com/petclinic/backend/domain/repository/InfraRepository.java
@@ -1,0 +1,13 @@
+package com.petclinic.backend.domain.repository;
+
+import com.petclinic.backend.domain.entity.Infra;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+@Repository
+public interface InfraRepository extends JpaRepository<Infra, String> {
+}

--- a/src/main/java/com/petclinic/backend/domain/repository/InfraScheduleRepository.java
+++ b/src/main/java/com/petclinic/backend/domain/repository/InfraScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.petclinic.backend.domain.repository;
+
+import com.petclinic.backend.domain.entity.InfraSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InfraScheduleRepository extends JpaRepository<InfraSchedule, String> {
+}

--- a/src/main/java/com/petclinic/backend/domain/repository/MedicalHistoryRepository.java
+++ b/src/main/java/com/petclinic/backend/domain/repository/MedicalHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.petclinic.backend.domain.repository;
+
+import com.petclinic.backend.domain.entity.MedicalHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MedicalHistoryRepository extends JpaRepository<MedicalHistory, String> {
+}

--- a/src/main/java/com/petclinic/backend/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/petclinic/backend/domain/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.petclinic.backend.domain.repository;
+
+import com.petclinic.backend.domain.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, String> {
+}

--- a/src/main/java/com/petclinic/backend/domain/repository/ReceptionRepository.java
+++ b/src/main/java/com/petclinic/backend/domain/repository/ReceptionRepository.java
@@ -1,0 +1,7 @@
+package com.petclinic.backend.domain.repository;
+
+import com.petclinic.backend.domain.entity.Reception;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReceptionRepository extends JpaRepository<Reception, String> {
+}

--- a/src/main/java/com/petclinic/backend/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/petclinic/backend/domain/repository/ReservationRepository.java
@@ -1,0 +1,7 @@
+package com.petclinic.backend.domain.repository;
+
+import com.petclinic.backend.domain.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<Reservation, String> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/example?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=1234


### PR DESCRIPTION
## Description
스케줄 쪽 테이블 3개, 진료 기록 테이블, 예약 쪽 테이블 3개에 대한
entity, repository 생성

## Changes detail
- Add Infra, InfraScheduleId, InfraSchedule, DoctorScheduleId, DoctorSchedule entities and repositories
- Add MedicalHistory entity and repository
- Add Reservation, Reception, Payment entities and repositories

### Checklist

- [ ] Test case
- [ ] End of work
